### PR TITLE
Add customizable color inputs and edge indicators

### DIFF
--- a/components/mindmap-canvas.tsx
+++ b/components/mindmap-canvas.tsx
@@ -26,6 +26,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { isValidCssColor } from "@/lib/color"
 
 const nodeTypes = {
   mindmap: MindMapNode,
@@ -72,6 +73,15 @@ const EDGE_COLORS = [
   "oklch(0.45 0.15 60)",  // Yellow
   "oklch(0.45 0.15 120)", // Lime
 ]
+
+const EDGE_DEFAULT_STYLE: Required<Pick<CustomEdgeData, "size" | "dashed" | "animated">> & {
+  indicator: NonNullable<CustomEdgeData["indicator"]>
+} = {
+  size: 2,
+  dashed: false,
+  animated: false,
+  indicator: "none",
+}
 
 const EXTENDED_EMOJI_LIST = [
   "💡",
@@ -207,11 +217,10 @@ export function MindMapCanvas() {
   const [showEmojiPanel, setShowEmojiPanel] = useState(false)
   const [selectedEdge, setSelectedEdge] = useState<Edge | null>(null)
   const [sourceColors, setSourceColors] = useState<{ [key: string]: string }>({})
-  const [edgeSettings, setEdgeSettings] = useState({
-    size: 2,
-    dashed: false,
-    animated: false,
-  })
+  const [nodeColorInput, setNodeColorInput] = useState("")
+  const [edgeColorInput, setEdgeColorInput] = useState("")
+  const [nodeColorValid, setNodeColorValid] = useState(true)
+  const [edgeColorValid, setEdgeColorValid] = useState(true)
 
   useEffect(() => {
     const selected = nodes.find((node) => node.selected)
@@ -219,9 +228,32 @@ export function MindMapCanvas() {
   }, [nodes])
 
   useEffect(() => {
+    if (selectedNode) {
+      const colorValue = (selectedNode.data.color as string) || ""
+      setNodeColorInput(colorValue)
+      setNodeColorValid(true)
+    } else {
+      setNodeColorInput("")
+      setNodeColorValid(true)
+    }
+  }, [selectedNode])
+
+  useEffect(() => {
     const selected = edges.find((edge) => edge.selected)
     setSelectedEdge(selected || null)
   }, [edges])
+
+  useEffect(() => {
+    if (selectedEdge) {
+      const edgeData = selectedEdge.data as CustomEdgeData
+      const colorValue = edgeData?.color || EDGE_COLORS[0]
+      setEdgeColorInput(colorValue)
+      setEdgeColorValid(true)
+    } else {
+      setEdgeColorInput("")
+      setEdgeColorValid(true)
+    }
+  }, [selectedEdge])
 
   useEffect(() => {
     if (isUndoRedoAction.current) {
@@ -337,6 +369,28 @@ export function MindMapCanvas() {
     [selectedNode, setNodes],
   )
 
+  const handleNodeColorInputChange = useCallback(
+    (value: string) => {
+      setNodeColorInput(value)
+      const isValid = isValidCssColor(value)
+      setNodeColorValid(isValid)
+      if (isValid) {
+        updateSelectedNode({ color: value })
+      }
+    },
+    [updateSelectedNode],
+  )
+
+  const handleNodeColorInputBlur = useCallback(() => {
+    if (nodeColorValid || !selectedNode) {
+      return
+    }
+
+    const fallbackColor = (selectedNode.data.color as string) || ""
+    setNodeColorInput(fallbackColor)
+    setNodeColorValid(true)
+  }, [nodeColorValid, selectedNode])
+
   const exportMindmap = useCallback(() => {
     const data = {
       nodes,
@@ -396,14 +450,15 @@ export function MindMapCanvas() {
       type: "mindmap",
       data: {
         color: sourceColor,
-        size: edgeSettings.size,
-        dashed: edgeSettings.dashed,
-        animated: edgeSettings.animated,
+        size: EDGE_DEFAULT_STYLE.size,
+        dashed: EDGE_DEFAULT_STYLE.dashed,
+        animated: EDGE_DEFAULT_STYLE.animated,
+        indicator: EDGE_DEFAULT_STYLE.indicator,
       },
     }
 
     setEdges((eds) => addEdge(newEdge, eds))
-  }, [setEdges, sourceColors, edgeSettings])
+  }, [setEdges, sourceColors])
 
   // Auto-arrange algorithm
   const autoArrange = useCallback(() => {
@@ -512,23 +567,53 @@ export function MindMapCanvas() {
       setEdges((eds) =>
         eds.map((edge) => {
           if (edge.id === selectedEdge.id) {
+            const mergedData: CustomEdgeData = { ...(edge.data as CustomEdgeData), ...updates }
             return {
               ...edge,
-              data: { ...edge.data, ...updates },
+              data: mergedData,
             }
           }
           return edge
         }),
       )
+      if (updates.color && selectedEdge.source) {
+        setSourceColors((prev) => ({
+          ...prev,
+          [selectedEdge.source!]: updates.color as string,
+        }))
+      }
     },
-    [selectedEdge, setEdges],
+    [selectedEdge, setEdges, setSourceColors],
   )
 
-  const updateEdgeSettings = useCallback(
-    (updates: Partial<typeof edgeSettings>) => {
-      setEdgeSettings(prev => ({ ...prev, ...updates }))
+  const handleEdgeColorInputChange = useCallback(
+    (value: string) => {
+      setEdgeColorInput(value)
+      const isValid = isValidCssColor(value)
+      setEdgeColorValid(isValid)
+      if (isValid) {
+        updateSelectedEdge({ color: value })
+      }
     },
-    [],
+    [updateSelectedEdge],
+  )
+
+  const handleEdgeColorInputBlur = useCallback(() => {
+    if (edgeColorValid || !selectedEdge) {
+      return
+    }
+
+    const edgeData = selectedEdge.data as CustomEdgeData
+    const fallbackColor = edgeData?.color || EDGE_COLORS[0]
+    setEdgeColorInput(fallbackColor)
+    setEdgeColorValid(true)
+  }, [edgeColorValid, selectedEdge])
+
+  const handleEdgeIndicatorChange = useCallback(
+    (value: CustomEdgeData["indicator"]) => {
+      updateSelectedEdge({ indicator: value })
+    },
+    [updateSelectedEdge],
   )
 
   return (
@@ -716,6 +801,35 @@ export function MindMapCanvas() {
                   />
                 ))}
               </div>
+              <div className="space-y-1 pt-1">
+                <Label htmlFor="node-color-code" className="text-[9px]">
+                  Color code
+                </Label>
+                <div className="flex items-center gap-1.5">
+                  <Input
+                    id="node-color-code"
+                    value={nodeColorInput}
+                    onChange={(e) => handleNodeColorInputChange(e.target.value)}
+                    onBlur={handleNodeColorInputBlur}
+                    className="h-6 text-[11px]"
+                    placeholder="#7c3aed or rgb(124, 58, 237)"
+                    aria-invalid={!nodeColorValid}
+                  />
+                  <span
+                    className="h-6 w-6 rounded border border-border/60"
+                    style={{
+                      backgroundColor:
+                        nodeColorValid && nodeColorInput
+                          ? nodeColorInput
+                          : (selectedNode.data.color as string),
+                    }}
+                    aria-hidden="true"
+                  />
+                </div>
+                {!nodeColorValid && (
+                  <p className="text-[9px] text-destructive">Enter a valid CSS color value.</p>
+                )}
+              </div>
             </div>
 
             <Separator />
@@ -758,6 +872,35 @@ export function MindMapCanvas() {
                   />
                 ))}
               </div>
+              <div className="space-y-1 pt-1">
+                <Label htmlFor="edge-color-code" className="text-[9px]">
+                  Color code
+                </Label>
+                <div className="flex items-center gap-1.5">
+                  <Input
+                    id="edge-color-code"
+                    value={edgeColorInput}
+                    onChange={(e) => handleEdgeColorInputChange(e.target.value)}
+                    onBlur={handleEdgeColorInputBlur}
+                    className="h-6 text-[11px]"
+                    placeholder="#64748b or rgb(100, 116, 139)"
+                    aria-invalid={!edgeColorValid}
+                  />
+                  <span
+                    className="h-6 w-6 rounded border border-border/60"
+                    style={{
+                      backgroundColor:
+                        edgeColorValid && edgeColorInput
+                          ? edgeColorInput
+                          : ((selectedEdge.data as CustomEdgeData)?.color || EDGE_COLORS[0]),
+                    }}
+                    aria-hidden="true"
+                  />
+                </div>
+                {!edgeColorValid && (
+                  <p className="text-[9px] text-destructive">Enter a valid CSS color value.</p>
+                )}
+              </div>
             </div>
 
             <div className="space-y-1">
@@ -797,6 +940,21 @@ export function MindMapCanvas() {
                   Animated
                 </label>
               </div>
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="edge-indicator" className="text-[9px]">
+                Indicator
+              </Label>
+              <select
+                id="edge-indicator"
+                value={(selectedEdge.data as CustomEdgeData)?.indicator || "none"}
+                onChange={(e) => handleEdgeIndicatorChange(e.target.value as CustomEdgeData["indicator"])}
+                className="h-6 w-full rounded-md border border-input bg-background px-2 text-[11px]"
+              >
+                <option value="none">None</option>
+                <option value="arrow">Arrow</option>
+              </select>
             </div>
 
             <div className="space-y-1">
@@ -933,36 +1091,6 @@ export function MindMapCanvas() {
               <Layout className="h-4 w-4" />
               Arrange
             </Button>
-            <div className="flex items-center gap-2 px-2 py-1 bg-background/50 rounded border">
-              <Label className="text-xs text-muted-foreground">Edge:</Label>
-              <input
-                type="range"
-                min="1"
-                max="8"
-                value={edgeSettings.size}
-                onChange={(e) => updateEdgeSettings({ size: Number(e.target.value) })}
-                className="w-16"
-                title="Edge thickness"
-              />
-              <label className="flex items-center gap-1 text-xs">
-                <input
-                  type="checkbox"
-                  checked={edgeSettings.dashed}
-                  onChange={(e) => updateEdgeSettings({ dashed: e.target.checked })}
-                  className="rounded"
-                />
-                Dashed
-              </label>
-              <label className="flex items-center gap-1 text-xs">
-                <input
-                  type="checkbox"
-                  checked={edgeSettings.animated}
-                  onChange={(e) => updateEdgeSettings({ animated: e.target.checked })}
-                  className="rounded"
-                />
-                Animated
-              </label>
-            </div>
             <input ref={fileInputRef} type="file" accept=".json" onChange={importMindmap} className="hidden" />
           </div>
         </Panel>

--- a/components/mindmap-edge.tsx
+++ b/components/mindmap-edge.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 import { memo } from "react"
-import { EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge } from "@xyflow/react"
+import { EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge, MarkerType } from "@xyflow/react"
 
 export interface CustomEdgeData extends Record<string, unknown> {
   color?: string
@@ -10,6 +10,7 @@ export interface CustomEdgeData extends Record<string, unknown> {
   dashed?: boolean
   animated?: boolean
   label?: string
+  indicator?: "none" | "arrow"
 }
 
 const EDGE_COLORS = [
@@ -54,6 +55,7 @@ export const MindMapEdge = memo(({
   const edgeSize = data?.size || 2
   const isDashed = data?.dashed || false
   const isAnimated = data?.animated || false
+  const indicator = data?.indicator || "none"
 
   const edgeStyle = {
     ...style,
@@ -63,13 +65,23 @@ export const MindMapEdge = memo(({
     strokeDashoffset: isAnimated && isDashed ? "0" : "none",
   }
 
+  const markerEndDefinition =
+    indicator === "arrow"
+      ? {
+          type: MarkerType.ArrowClosed,
+          color: edgeColor,
+          width: 22,
+          height: 22,
+        }
+      : undefined
+
   return (
     <>
       <BaseEdge
         id={id}
         path={edgePath}
         style={edgeStyle}
-        markerEnd={markerEnd}
+        markerEnd={markerEndDefinition ?? markerEnd}
         className={isAnimated ? (isDashed ? "animate-flow" : "animate-pulse") : ""}
       />
       {data?.label && (

--- a/lib/color.ts
+++ b/lib/color.ts
@@ -1,0 +1,39 @@
+export function isValidCssColor(value: string): boolean {
+  if (typeof value !== "string") {
+    return false
+  }
+
+  const normalized = value.trim()
+  if (!normalized) {
+    return false
+  }
+
+  if (typeof window !== "undefined" && window.CSS?.supports) {
+    return window.CSS.supports("color", normalized)
+  }
+
+  if (typeof CSS !== "undefined" && typeof CSS.supports === "function") {
+    return CSS.supports("color", normalized)
+  }
+
+  if (typeof document !== "undefined") {
+    const element = document.createElement("div")
+    element.style.color = ""
+    element.style.color = normalized
+    return element.style.color !== ""
+  }
+
+  const HEX_REGEX = /^#(?:[0-9a-fA-F]{3}){1,2}$/
+  const RGB_REGEX = /^rgb\(\s*(?:\d{1,3}%?\s*,\s*){2}\d{1,3}%?\s*\)$/
+  const RGBA_REGEX = /^rgba\(\s*(?:\d{1,3}%?\s*,\s*){3}(?:0|1|0?\.\d+)\s*\)$/
+  const HSL_REGEX = /^hsl\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*\)$/
+  const HSLA_REGEX = /^hsla\(\s*\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\s*,\s*(?:0|1|0?\.\d+)\s*\)$/
+
+  return (
+    HEX_REGEX.test(normalized) ||
+    RGB_REGEX.test(normalized) ||
+    RGBA_REGEX.test(normalized) ||
+    HSL_REGEX.test(normalized) ||
+    HSLA_REGEX.test(normalized)
+  )
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:check": "node scripts/dev-with-port-check.js",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --experimental-strip-types --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/tests/color.test.ts
+++ b/tests/color.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict"
+import { describe, it, beforeEach, afterEach } from "node:test"
+
+import { isValidCssColor } from "../lib/color.ts"
+
+describe("isValidCssColor", () => {
+  let originalCSS: typeof globalThis.CSS
+
+  beforeEach(() => {
+    originalCSS = globalThis.CSS
+    // Ensure CSS API is not defined unless explicitly set inside a test
+    // @ts-expect-error - allow manipulating the global for tests
+    delete globalThis.CSS
+  })
+
+  afterEach(() => {
+    if (originalCSS) {
+      globalThis.CSS = originalCSS
+    } else {
+      // @ts-expect-error - cleanup test mutation
+      delete globalThis.CSS
+    }
+  })
+
+  it("returns true for valid hex values", () => {
+    assert.equal(isValidCssColor("#123abc"), true)
+    assert.equal(isValidCssColor("#fff"), true)
+  })
+
+  it("returns true for valid functional color notations", () => {
+    assert.equal(isValidCssColor("rgb(255, 0, 0)"), true)
+    assert.equal(isValidCssColor("rgba(34, 12, 64, 0.5)"), true)
+    assert.equal(isValidCssColor("hsl(210, 50%, 40%)"), true)
+    assert.equal(isValidCssColor("hsla(90, 100%, 50%, 0.75)"), true)
+  })
+
+  it("returns false for invalid entries", () => {
+    assert.equal(isValidCssColor(""), false)
+    assert.equal(isValidCssColor("invalid-color"), false)
+    assert.equal(isValidCssColor("#12"), false)
+  })
+
+  it("defers to CSS.supports when available", () => {
+    // @ts-expect-error - simulate browser CSS API
+    globalThis.CSS = {
+      supports: (property: string, value: string) => property === "color" && value === "papayawhip",
+    }
+
+    assert.equal(isValidCssColor("papayawhip"), true)
+
+    // @ts-expect-error - simulate environment rejecting the value
+    globalThis.CSS = {
+      supports: () => false,
+    }
+
+    assert.equal(isValidCssColor("papayawhip"), false)
+  })
+})


### PR DESCRIPTION
## Summary
- add reusable CSS color validation utility and expose manual color inputs for node and edge editors
- extend edge styling with optional arrow indicators and live previews without relying on global edge controls
- wire up Node.js test runner to cover color validation helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e60acb5edc8330a7b74ec1de42d7f5